### PR TITLE
Add No Updates Available window.

### DIFF
--- a/src/Magpie/Magpie.Tests/MagpieServiceTests.cs
+++ b/src/Magpie/Magpie.Tests/MagpieServiceTests.cs
@@ -1,25 +1,31 @@
 ﻿using System;
 using System.Reflection;
+using Magpie.Models;
+using Magpie.Services;
 using Magpie.Tests.Mocks;
+using Magpie.ViewModels;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
 
 namespace Magpie.Tests
 {
     [TestClass]
     public class MagpieServiceTests
     {
+        private MockMagpieService _mockMagpieService;
+
         [TestInitialize]
         public void Initialize()
         {
             AssemblyInjector.Inject();
+            _mockMagpieService = new MockMagpieService("validContentUrl");
         }
 
         [TestMethod]
         public void TestValidJson()
         {
-            var mockMagpieService = new MockMagpieService("validContentUrl");
-            mockMagpieService.CheckInBackground("validContentUrl");
-            var appcast = mockMagpieService.RemoteAppcast;
+            _mockMagpieService.CheckInBackground("validContentUrl");
+            var appcast = _mockMagpieService.RemoteAppcast;
             Assert.IsNotNull(appcast);
             Assert.AreEqual("Magpie", appcast.Title);
             Assert.AreEqual(new Version(0, 0, 1), appcast.Version);
@@ -29,10 +35,28 @@ namespace Magpie.Tests
         public void TestAppcastAvailableRaiseEvent()
         {
             var raised = false;
-            var mockMagpieService = new MockMagpieService("validContentUrl");
-            mockMagpieService.RemoteAppcastAvailableEvent += (s, a) => { raised = true; };
-            mockMagpieService.CheckInBackground("validContentUrl");
+            _mockMagpieService.RemoteAppcastAvailableEvent += (s, a) => { raised = true; };
+            _mockMagpieService.CheckInBackground("validContentUrl");
             Assert.IsTrue(raised);
+        }
+
+        [TestMethod]
+        public void TestNoUpdatesWindowShown()
+        {
+            var updateDecider = Substitute.For<UpdateDecider>(new DebuggingWindowViewModel());
+            updateDecider.ShouldUpdate(Arg.Any<RemoteAppcast>(), true).Returns(false);
+            _mockMagpieService.UpdateDecider = updateDecider;
+            _mockMagpieService.ForceCheckInBackground("validContentUrl");
+            Assert.IsTrue(_mockMagpieService.ShowNoUpdatesWindowFlag);
+        }
+
+        [TestMethod]
+        public void TestUpdateWindowShown()
+        {
+            _mockMagpieService.UpdateDecider = Substitute.For<UpdateDecider>(new DebuggingWindowViewModel());
+            _mockMagpieService.UpdateDecider.ShouldUpdate(Arg.Any<RemoteAppcast>(), true).Returns(true);
+            _mockMagpieService.ForceCheckInBackground("validContentUrl");
+            Assert.IsTrue(_mockMagpieService.ShowUpdateWindowFlag);
         }
     }
 

--- a/src/Magpie/Magpie.Tests/Mocks/MockMagpieService.cs
+++ b/src/Magpie/Magpie.Tests/Mocks/MockMagpieService.cs
@@ -10,6 +10,8 @@ namespace Magpie.Tests.Mocks
     {
         private const string VALID_JSON = @"{ 'title': 'Magpie', 'version': '0.0.1', 'build_date': '10/03/2015', 'release_notes_url': '', 'artifact_url': 'https://dl.dropboxusercontent.com/u/83257/Updaters/Magpie/appcast.zip' }";
         internal RemoteAppcast RemoteAppcast { get; private set; }
+        internal bool ShowUpdateWindowFlag;
+        internal bool ShowNoUpdatesWindowFlag;
 
         public MockMagpieService(string validUrl, IDebuggingInfoLogger infoLogger = null) : base(new AppInfo(), infoLogger)
         {
@@ -28,6 +30,13 @@ namespace Magpie.Tests.Mocks
         protected override void ShowUpdateWindow(RemoteAppcast appcast)
         {
             // can't do in tests
+            ShowUpdateWindowFlag = true;
+        }
+
+        protected override void ShowNoUpdatesWindow()
+        {
+            // can't do in tests
+            ShowNoUpdatesWindowFlag = true;
         }
     }
 }

--- a/src/Magpie/Magpie/Magpie.csproj
+++ b/src/Magpie/Magpie/Magpie.csproj
@@ -80,6 +80,9 @@
     <Compile Include="Views\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\NoUpdatesWindow.xaml.cs">
+      <DependentUpon>NoUpdatesWindow.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models\RemoteAppcast.cs" />
@@ -120,6 +123,10 @@
     <Page Include="Views\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\NoUpdatesWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/src/Magpie/Magpie/Services/MagpieService.cs
+++ b/src/Magpie/Magpie/Services/MagpieService.cs
@@ -51,6 +51,10 @@ namespace Magpie.Services
                 {
                     ShowUpdateWindow(appcast);
                 }
+                else
+                {
+                    ShowNoUpdatesWindow();
+                }
             }
             catch (Exception ex)
             {
@@ -73,6 +77,13 @@ namespace Magpie.Services
                 window.Close();
                 ShowDownloadWindow(appcast);
             });
+            SetOwner(window);
+            window.ShowDialog();
+        }
+
+        protected virtual void ShowNoUpdatesWindow()
+        {
+            var window = new NoUpdatesWindow();
             SetOwner(window);
             window.ShowDialog();
         }

--- a/src/Magpie/Magpie/Services/UpdateDecider.cs
+++ b/src/Magpie/Magpie/Services/UpdateDecider.cs
@@ -6,7 +6,7 @@ using Magpie.Models;
 
 namespace Magpie.Services
 {
-    internal class UpdateDecider
+    public class UpdateDecider
     {
         private readonly IDebuggingInfoLogger _logger;
         private readonly RegistryIO _registryIO;
@@ -38,7 +38,7 @@ namespace Magpie.Services
             }
         }
 
-        internal UpdateDecider(IDebuggingInfoLogger debuggingInfoLogger)
+        public UpdateDecider(IDebuggingInfoLogger debuggingInfoLogger)
         {
             _logger = debuggingInfoLogger;
             _registryIO = new RegistryIO();

--- a/src/Magpie/Magpie/Views/NoUpdatesWindow.xaml
+++ b/src/Magpie/Magpie/Views/NoUpdatesWindow.xaml
@@ -1,0 +1,39 @@
+﻿<Window x:Class="Magpie.Views.NoUpdatesWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="No Updates Available"
+        Width="300"
+        Height="150"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        UseLayoutRounding="True">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Margin="10, 20"
+                   Text="There are no updates available."
+                   TextAlignment="Center" />
+        <Button Grid.Row="1"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Content="OK"
+                IsCancel="True"
+                Padding="20,4" />
+        <Label Grid.Row="3"
+               Grid.Column="0"
+               Grid.ColumnSpan="2"
+               HorizontalAlignment="Center"
+               FontSize="13">
+            <Hyperlink Foreground="#BBBBBB"
+                       NavigateUri="https://github.com/ashokgelal/Magpie"
+                       RequestNavigate="PoweredBy_RequestNavigate"
+                       TextDecorations="None">
+                <Run Text="Powered by Magpie" />
+            </Hyperlink>
+        </Label>
+    </Grid>
+</Window>

--- a/src/Magpie/Magpie/Views/NoUpdatesWindow.xaml.cs
+++ b/src/Magpie/Magpie/Views/NoUpdatesWindow.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+using System.Windows.Navigation;
+
+namespace Magpie.Views
+{
+    public partial class NoUpdatesWindow
+    {
+        public NoUpdatesWindow()
+        {
+            InitializeComponent();
+            SetValue(NoIconBehavior.ShowIconProperty, false);
+        }
+
+        private void PoweredBy_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+            e.Handled = true;
+        }
+    }
+}


### PR DESCRIPTION
The "No Updates Available" window is shown when UpdateDecider.ShouldUpdate() returns false in MagpieService.Check().
Also had to make the UpdateDecider class public in order to be able to use NSubstitute on it for testing.