### PR TITLE
CSS Default Fix

### DIFF
--- a/src/Magpie/Magpie/ViewModels/MainWindowViewModel.cs
+++ b/src/Magpie/Magpie/ViewModels/MainWindowViewModel.cs
@@ -120,10 +120,8 @@ namespace Magpie.ViewModels
 
         protected virtual string GetStylesheet()
         {
-            var stylesheetStream = Resources.ResourceManager.GetStream("style");
-            if (stylesheetStream == null) return String.Empty;
-            var stylesheetReader = new StreamReader(stylesheetStream);
-            return stylesheetReader.ReadToEnd();
+            var stylesheetStream = Resources.ResourceManager.GetObject("style") as string;
+            return stylesheetStream ?? String.Empty;
         }
     }
 }


### PR DESCRIPTION
For some reason, style is no longer accepted as a string, but is seen as an object by the resource manager. This is the fix. All unit tests pass.