### PR TITLE
Fix the version number comparison

### DIFF
--- a/src/Magpie/Magpie.Tests/HelpersTests.cs
+++ b/src/Magpie/Magpie.Tests/HelpersTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Magpie.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Magpie.Tests
+{
+    [TestClass]
+    public class HelpersTests
+    {
+        [TestMethod]
+        public void TestVersionsAreEqual()
+        {
+            var version1 = new Version(0, 4, 3, 2);
+            var version2 = new Version(0, 4, 3, 2);
+            Assert.IsFalse(version1.IsHigherThan(version2));
+            Assert.IsFalse(version2.IsHigherThan(version1));
+        }
+
+        [TestMethod]
+        public void TestOnlyMajorNumbersDiffer()
+        {
+            var higherVersion = new Version(5, 4, 0, 2);
+            var lowerVersion = new Version(4, 4, 0, 2);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        }
+
+        [TestMethod]
+        public void TestOnlyMinorNumbersDiffer()
+        {
+            var higherVersion = new Version(5, 4, 3, 2);
+            var lowerVersion = new Version(5, 3, 3, 2);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        }
+
+        [TestMethod]
+        public void TestOnlyBuildNumbersDiffer()
+        {
+            var higherVersion = new Version(5, 4, 3, 2);
+            var lowerVersion = new Version(5, 4, 2, 2);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        }
+
+        [TestMethod]
+        public void TestOnlyRevisionNumbersDiffer()
+        {
+            var higherVersion = new Version(5, 4, 3, 2);
+            var lowerVersion = new Version(5, 4, 3, 1);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        }
+
+        [TestMethod]
+        public void TestMajorAndMinorNumbersDiffer()
+        {
+            var higherVersion = new Version(5, 4, 3, 2);
+            var lowerVersion = new Version(4, 6, 3, 2);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        }
+
+        [TestMethod]
+        public void TestMinorAndBuildNumbersDiffer()
+        {
+            var higherVersion = new Version(5, 4, 3, 2);
+            var lowerVersion = new Version(5, 2, 5, 2);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        }
+
+        [TestMethod]
+        public void TestBuildAndRevisionNumbersDiffer()
+        {
+            var higherVersion = new Version(5, 4, 3, 2);
+            var lowerVersion = new Version(5, 4, 1, 6);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        
+        }
+
+        [TestMethod]
+        public void TestUnknownRevisionNumber()
+        {
+            var higherVersion = new Version(3, 4, 0);
+            var lowerVersion = new Version(3, 3, 9, 9);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+
+            higherVersion = new Version(3, 4, 0, 9);
+            lowerVersion = new Version(3, 4, 0);
+            Assert.IsTrue(higherVersion.IsHigherThan(lowerVersion));
+            Assert.IsFalse(lowerVersion.IsHigherThan(higherVersion));
+        }
+    }
+}

--- a/src/Magpie/Magpie.Tests/Magpie.Tests.csproj
+++ b/src/Magpie/Magpie.Tests/Magpie.Tests.csproj
@@ -55,6 +55,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="HelpersTests.cs" />
     <Compile Include="MagpieServiceTests.cs" />
     <Compile Include="MainWindowViewModelTests.cs" />
     <Compile Include="Mocks\MockMagpieService.cs" />

--- a/src/Magpie/Magpie/Services/Helpers.cs
+++ b/src/Magpie/Magpie/Services/Helpers.cs
@@ -4,12 +4,9 @@ namespace Magpie.Services
 {
     internal static class Helpers
     {
-        internal static bool IsHigherThan(this Version version, Version otherVersion)
+        internal static bool IsHigherThan(this Version thisVersion, Version otherVersion)
         {
-            return version.Revision > otherVersion.Revision
-                               || version.Build > otherVersion.Build
-                               || version.Minor > otherVersion.Minor
-                               || version.Major > otherVersion.Major;
+             return thisVersion.CompareTo(otherVersion) > 0;
         }
     }
 }

--- a/src/Magpie/Magpie/Services/UpdateDecider.cs
+++ b/src/Magpie/Magpie/Services/UpdateDecider.cs
@@ -99,7 +99,7 @@ namespace Magpie.Services
 
         protected virtual bool CheckVersion(RemoteAppcast appcast)
         {
-            var curVer = Assembly.GetExecutingAssembly().GetName().Version;
+            var curVer = Assembly.GetEntryAssembly().GetName().Version;
             var isHigherVersionAvailable = appcast.Version.IsHigherThan(curVer);
             _logger.Log(string.Format("Higher version of app is {0}available", isHigherVersionAvailable ? "" : "not "));
             return isHigherVersionAvailable;


### PR DESCRIPTION
Use the EntryAssembly instead of the ExecutingAssembly to fetch the current version number. Use the built in CompareTo method for Versions. 